### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,62 @@
 # Apollo
 
-Updated README soon™
+Apollo is a custom Discord bot built on top of discord.js
+
+## Installation
+
+Start off by cloning the repo:
+
+```shell
+git clone https://github.com/cdevoogd/apollo.git
+```
+If you don't already, you will need to install Node and NPM.
+
+Then, you can install Apollo's dependencies using NPM:
+
+```shell
+npm install
+```
+
+If you don't already have one, you will need to set up MongoDB to use with Apollo. Personally, I recommend using [Atlas by MongoDB](https://www.mongodb.com/cloud/atlas).
+
+## Configuration
+
+### config.js
+
+Apollo uses a `config.js` file inside of the `src` directory to hold data that doesn't really need to be in the database such as the command prefix.
+
+The `config.js` file that is currently in there is one that I use for testing, and you can easily change the values to fit your needs/wants. I have commented what the values are used for.
+
+### .env
+
+Apollo uses a .env file for more sensitive information such as his access token and the MongoDB information. 
+
+Create a `.env` file inside of the root directory with these keys:
+
+```
+ACCESS_TOKEN=
+MONGO_HOST=
+MONGO_DB_NAME=
+MONGO_USER=
+MONGO_PASS=
+```
+
+`ACCESS_TOKEN` will be your bot's token given to you in your Discord developer page for your application.
+
+`MONGO_DB_NAME`, `MONGO_USER`, and `MONGO_PASS` are self-explanatory, but if you need to get your host you can do this through the Atlas website.
+
+To get your MongoDB connection information (if using Atlas), open the *connect* menu on your cluster page.
+
+![View of an Atlas cluster](https://i.imgur.com/8cpHb4M.png)
+
+After clicking *connect*, choose the *Connect Your Application* option.
+
+Finally, click *Short SRV connection string*.
+
+This will give you a string that looks like this:
+
+```
+mongodb+srv://<USERNAME>:<PASSWORD>@cluster-name-fcgnw.gcp.mongodb.net/test?retryWrites=true
+```
+
+The host would be the `cluster-name-fcgnw.gcp.mongodb.net` portion of the address.

--- a/src/apollo.js
+++ b/src/apollo.js
@@ -27,7 +27,7 @@ client.on('message', (msg) => {
 });
 
 client.on('voiceStateUpdate', (oldMember, newMember) => {
-  eventVoiceStatusUpdate.run(dynamicInfo, oldMember, newMember);
+  eventVoiceStatusUpdate.run(config, dynamicInfo, oldMember, newMember);
 });
 
 client.login(process.env.ACCESS_TOKEN);

--- a/src/apollo.js
+++ b/src/apollo.js
@@ -12,7 +12,9 @@ const config = require('./config');
 // Database
 const mongo = require('./database/operations');
 
+// Connect to the database
 mongo.connect();
+// Cache the commands and dynamic channel information from the database
 let commands = mongo.getCommands();
 let dynamicInfo = mongo.getDynamicInfo();
 
@@ -21,7 +23,7 @@ client.on('ready', () => {
 });
 
 client.on('message', (msg) => {
-  eventMessage.run(config, commands, client, msg);
+  eventMessage.run(config, commands, dynamicInfo, client, msg);
 });
 
 client.on('voiceStateUpdate', (oldMember, newMember) => {

--- a/src/commands/general/lock.js
+++ b/src/commands/general/lock.js
@@ -1,0 +1,16 @@
+/**
+ * Command - !lock
+ * Allows dynamic channels to be locked, keeping random users from joining.
+ */
+
+module.exports.exec = async (config, dynamicInfo, message) => {
+  const currentVC = message.member.voiceChannel;
+  const dyanmicInfoResolved = await dynamicInfo;
+  const dyanmicCategories = Object.keys(dyanmicInfoResolved);
+
+  // Make sure the user is in a voice channel and that the channel is dynamic
+  if (currentVC && dyanmicCategories.includes(currentVC.parentID)) {
+    currentVC.overwritePermissions(message.guild.defaultRole, { CONNECT: false });
+    currentVC.overwritePermissions(config.adminRoleID, { CONNECT: true });
+  }
+};

--- a/src/commands/general/unlock.js
+++ b/src/commands/general/unlock.js
@@ -1,0 +1,17 @@
+/**
+ * Command - !unlock
+ * Allows dynamic channels to be unlocked, after being locked.
+ */
+
+module.exports.exec = async (config, dynamicInfo, message) => {
+  const currentVC = message.member.voiceChannel;
+  const dyanmicInfoResolved = await dynamicInfo;
+  const dyanmicCategories = Object.keys(dyanmicInfoResolved);
+
+  // Make sure the user is in a voice channel and that the channel is dynamic
+  if (currentVC && dyanmicCategories.includes(currentVC.parentID)) {
+    // Reset the permissions that are overwritten when locked.
+    currentVC.overwritePermissions(message.guild.defaultRole, { CONNECT: null });
+    currentVC.overwritePermissions(config.adminRoleID, { CONNECT: null });
+  }
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,10 @@
 module.exports = {
   // Prefix for built-in commands
   prefix: '!',
+  // The role ID for the administrator role. This is the role that is allowed to join locked channels when they are locked.
+  adminRoleID: '201908872867348480',
+  // Array of ALL staff role IDs (including adminRoleID). Users with these IDs will be able to use staff commands.
+  staffRoleIDs: [
+    
+  ]
 };

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -6,11 +6,14 @@
  * 
  */
 
-module.exports.run = (config, commands, client, message) => {
+module.exports.run = (config, commands, dynamicInfo, client, message) => {
   const messageContent = message.content.split(' ');
   const pre = config.prefix;
-  // Commands
+  // Built-In Commands
   const addStaffID = require('../commands/staff/addstaffid');
+  const lock = require('../commands/general/lock');
+  const unlock = require('../commands/general/unlock');
+  // Custom Commands
   const customCommands = require('../commands/custom-commands');
   
 
@@ -19,20 +22,30 @@ module.exports.run = (config, commands, client, message) => {
     return;
   }
 
-  switch(messageContent[0].toLowerCase()) {
-    case pre + 'addstaffid':
-      addStaffID.exec(message);
-      break;
-    default:
-      // Check for custom commands. Put in default so they dont run if they happen to overlap with another command.
-      for (let word of messageContent) {
-        // Check for custom chat commands, prefix or not.
-        commands.then((commandList => {
-          if (commandList.includes(word)) {
-            customCommands.exec(message, word);
-          }
-        }));
-      }
+  // Only run in text channels, not DMs
+  if (message.channel.type === 'text') {
+    switch (messageContent[0].toLowerCase()) {
+      case pre + 'addstaffid':
+        addStaffID.exec(message);
+        break;
+      case pre + 'lock':
+        lock.exec(config, dynamicInfo, message);
+        break;
+      case pre + 'unlock':
+        unlock.exec(config, dynamicInfo, message);
+        break;
+      default:
+        // Checking for custom commands
+        for (let word of messageContent) {
+          commands.then((commandList => {
+            if (commandList.includes(word)) {
+              customCommands.exec(message, word);
+            }
+          }));
+        }
+    }
   }
+
+  
 };
 


### PR DESCRIPTION
# CHANGELOG
## 1.1.0
### Added
* !lock command
	* When in a dynamic channel, this command will lock the channel, stopping others from being able to join.  The exception to this is people with the admin role set in the config file. 
* !unlock command
### Changed
* When dynamic channels become empty, the bot will check if they are locked and unlock them if they are.
* The bot no longer responds to commands through DM.
* README has been updated
- Staff IDs have been moved to the config file. This change was made because they will not be modified often, and it makes them much easier to access.
### Fixed
- Issue #3 - Fixed a bug where the bot would delete the first channel wen you joined the first channel, then switched to the newly created channel.