### PR TITLE
Edited `lock` to deny connection to everyone, including admins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,45 +1,12 @@
-# PYTHON
-
-__pycache__/
-*.py[cod]
-*$py.class
-pip-log.txt
-pip-delete-this-directory.txt
-
-.ropeproject
-
-# JAVASCRIPT
-node_modules
-
-# VS CODE / IDEs
-.vscode
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-
-.idea
-
-# WINDOWS
-Thumbs.db
-ehthumbs.db
-ehthumbs_vista.db
-[Dd]esktop.ini
-$RECYCLE.BIN/
-
-*.cab
-*.msi
-*.msix
-*.msm
-*.msp
-
-*.lnk
-
-# MACOS
 .DS_Store
 
-# Environment Variables
 .env
 
+.vscode
+
+node_modules
+
 src/config.js
+
+
+

--- a/src/apollo.js
+++ b/src/apollo.js
@@ -39,7 +39,9 @@ client.on('ready', () => {
   eventReady.run(client);
 });
 
-client.on('error', console.error);
+client.on('error', (err) => {
+  console.error(err.message);
+});
 
 client.on('message', (message) => {
   eventMessage.run(client, message);

--- a/src/commands/dynamic-channels/lock.js
+++ b/src/commands/dynamic-channels/lock.js
@@ -19,7 +19,6 @@ module.exports.exec = async function(message) {
   function lockChannel() {
     if (voiceChannel && dynamicConfig.hasOwnProperty(voiceChannel.parentID)) {
       voiceChannel.overwritePermissions(message.guild.defaultRole, { CONNECT: false });
-      voiceChannel.overwritePermissions(config.adminRoleID, { CONNECT: true });
       message.react('🔒');
     }
   }

--- a/src/commands/dynamic-channels/unlock.js
+++ b/src/commands/dynamic-channels/unlock.js
@@ -19,7 +19,6 @@ module.exports.exec = async function(message) {
   function unlockChannel() {
     if (voiceChannel && dynamicConfig.hasOwnProperty(voiceChannel.parentID)) {
       voiceChannel.overwritePermissions(message.guild.defaultRole, { CONNECT: null });
-      voiceChannel.overwritePermissions(config.adminRoleID, { CONNECT: null });
       message.react('🔓');
     }
   }

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -69,7 +69,6 @@ module.exports.run = async function(memberOld, memberNew) {
   function unlockLockedChannel(currentChannel) {
     if (!currentChannel.permissionsFor(roleEveryone).toArray().includes('CONNECT')) {
       currentChannel.overwritePermissions(roleEveryone, { CONNECT: null });
-      currentChannel.overwritePermissions(config.adminRoleID, { CONNECT: null });
     }
 
   }


### PR DESCRIPTION
### Changed
* Changed the !lock command to deny everyone the ability to join locked channels. Should an admin need to get to someone in a locked channel, they can either have a person inside unlock it, or simply move them to a different channel.