### PR TITLE
Add DeepSource static analysis

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,25 @@
+version = 1
+
+test_patterns = [
+    "test/**",
+    "**/*_test.go"
+]
+
+[[analyzers]]
+name = "docker"
+enabled = true
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_root = "github.com/cdevoogd/apollo"
+
+[[analyzers]]
+name = "secrets"
+enabled = true
+
+[[analyzers]]
+name = "sql"
+enabled = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*
 
 # Some dotfiles are important to commit
+!.deepsource.toml
 !.gitignore
 !.gitattributes
 !.github


### PR DESCRIPTION
This adds DeepSource analysis for the following languages to the repo:
- [Docker](https://deepsource.io/docs/analyzer/docker)
- [Go](https://deepsource.io/docs/analyzer/go/)
- [Secrets](https://deepsource.io/docs/analyzer/secrets)
- [SQL](https://deepsource.io/docs/analyzer/sql)

Closes GH-33