### PR TITLE
Use Docker for building/running Apollo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Some dotfiles are important to commit
 !.deepsource.toml
+!.dockerignore
 !.gitignore
 !.gitattributes
 !.github

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+DOCKERFILE = build/Dockerfile
+
+.DEFAULT_GOAL := apollo
+
+.PHONY: help
+help: ## Print out a help message that displays all available targets
+	@echo "Available make targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: apollo
+apollo: ## Build Apollo within a container. This is the default target.
+	DOCKER_BUILDKIT=1 docker build  -f $(DOCKERFILE) -t apollo:latest . --target bin
+
+.PHONY: test
+test: ## Run unit tests within a container
+	DOCKER_BUILDKIT=1 docker build -f $(DOCKERFILE) . --target unit-test

--- a/build/.dockerignore
+++ b/build/.dockerignore
@@ -1,0 +1,6 @@
+**
+
+go.mod
+go.sum
+
+cmd/*.go

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.16 AS base
+ENV CGO_ENABLED=0
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+COPY . .
+
+FROM base as build
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=linux go build -o /src/out/apollo /src/cmd/apollo/main.go
+
+FROM base AS unit-test
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go test -v ./...
+
+FROM alpine:3.14 as bin
+COPY --from=build /src/out/apollo /
+CMD [ "/apollo" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  apollo:
+    container_name: apollo
+    image: apollo
+    environment:
+      - DISCORD_API_TOKEN


### PR DESCRIPTION
Docker is now used for building and running the bot
- Build using `make` or `make apollo` 
- Run using `docker-compose up` 

Closes GH-34